### PR TITLE
Fix stringify to not crash on null

### DIFF
--- a/packages/enzyme-matchers/src/utils/__tests__/__snapshots__/stringify.test.js.snap
+++ b/packages/enzyme-matchers/src/utils/__tests__/__snapshots__/stringify.test.js.snap
@@ -2,12 +2,14 @@ exports[`stringify works with circular structs 1`] = `
 "[33mfalsy[39m[90m:[39m [33m[31mfalse[33m[39m
 [33mtruthy[39m[90m:[39m [33m[32mtrue[33m[39m
 [33mstring[39m[90m:[39m [33m[90m\"string\"[33m[39m
+[33mnull[39m[90m:[39m [33m[90mnull[33m[39m
 [33mcircular[39m[90m:[39m [33m[90m[Circular][33m[39m
 [33mclass[39m[90m:[39m [33m[32mfunction Promise() { [native code] }[33m[39m
 [33marry[39m[90m:[39m [33m[90m[90m[[90m
   [31mfalse[90m
   [32mtrue[90m
   [90m\"string\"[90m
+  [90mnull[90m
   [90m[Circular][90m
   [32mfunction Promise() { [native code] }[90m
 [90m][90m[33m[39m"

--- a/packages/enzyme-matchers/src/utils/__tests__/stringify.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/stringify.test.js
@@ -6,6 +6,7 @@ describe('stringify', () => {
     proof.falsy = false;
     proof.truthy = true;
     proof.string = 'string';
+    proof.null = null;
     proof.circular = proof;
     proof.class = Promise;
     proof.arry = Object.keys(proof).map(k => proof[k]); // includes all other proofs

--- a/packages/enzyme-matchers/src/utils/stringify.js
+++ b/packages/enzyme-matchers/src/utils/stringify.js
@@ -20,6 +20,8 @@ function stringifySingle(key:string, value:any) : Array<string> {
     }
 
     stringifyingValue = colors.gray(`${initialBracket}${joined}${endingBracket}`);
+  } else if (value === null) {
+    stringifyingValue = colors.gray(value);
   } else if (typeof value === 'object') {
     stringifyingValue = colors.gray(value.toString());
   } else if (typeof value === 'string') {


### PR DESCRIPTION
stringify would try to `.toString()` on null because `typeof null === 'object'`