### PR TITLE
Prevent full render of shallow wrappers

### DIFF
--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeChecked--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeChecked--tests.js.snap
@@ -1,6 +1,6 @@
 exports[`toBeChecked provides contextual information for the message 1`] = `
 Object {
-  "actual": "Node HTML output: <input id=\"checked\" checked=\"\"/>",
+  "actual": "Node HTML output: <input id=\"checked\" defaultChecked={true} />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeDisabled--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBeDisabled--tests.js.snap
@@ -1,6 +1,6 @@
 exports[`toBeDisabled provides contextual information for the message 1`] = `
 Object {
-  "expected": "Node HTML output: <input id=\"disabled\" disabled=\"\"/>",
+  "expected": "Node HTML output: <input id=\"disabled\" disabled={true} />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBePresent--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toBePresent--tests.js.snap
@@ -1,6 +1,6 @@
 exports[`toBePresent provides contextual information for the message 1`] = `
 Object {
-  "actual": "Found Nodes: <span class=\"matches\"></span>",
+  "actual": "Found Nodes: <span className=\"matches\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toContainReact--tests.js.snap
@@ -1,7 +1,7 @@
 exports[`toContainReact provides contextual information for the message 1`] = `
 Object {
   "actual": "HTML Output of <Fixture>:
- <div><ul><li><span>User 1</span></li><li><span>User 2</span></li></ul></div>",
+ <div><ul><li><User index={1} /></li><li><User index={2} /></li></ul></div>",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveClassName--tests.js.snap
@@ -1,12 +1,12 @@
 exports[`toHaveClassName mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Found node output: <span class="bar baz"></span>",
+  "actual": "Found node output: <span class=\"bar baz\"></span>",
 }
 `;
 
-exports[`toHaveClassName mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> not to contain ".bar" for it's classname"`;
+exports[`toHaveClassName mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> not to contain \".bar\" for it\'s classname"`;
 
-exports[`toHaveClassName mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> to have className of ".bar" but instead found "bar baz""`;
+exports[`toHaveClassName mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> to have className of \".bar\" but instead found \"bar baz\""`;
 
 exports[`toHaveClassName mount works for multiple nodes (mount) 1`] = `
 Object {
@@ -24,24 +24,24 @@ Object {
 
 exports[`toHaveClassName shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Found node output: <span class="bar baz"></span>",
+  "actual": "Found node output: <span className=\"bar baz\" />",
 }
 `;
 
-exports[`toHaveClassName shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> not to contain ".bar" for it's classname"`;
+exports[`toHaveClassName shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> not to contain \".bar\" for it\'s classname"`;
 
-exports[`toHaveClassName shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> to have className of ".bar" but instead found "bar baz""`;
+exports[`toHaveClassName shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> to have className of \".bar\" but instead found \"bar baz\""`;
 
 exports[`toHaveClassName shallow works for multiple nodes (shallow) 1`] = `
 Object {
   "contextualInformation": Object {
     "actual": "Found node output: Multiple nodes found:
-0: <span className="baux"/>
-1: <span className="baux"/>
+0: <span className=\"baux\"/>
+1: <span className=\"baux\"/>
 ",
   },
-  "message": "Expected <Fixture, 2 span nodes found> to have className of ".baux" but instead found "baux"",
-  "negatedMessage": "Expected <Fixture, 2 span nodes found> not to contain ".baux" for it's classname",
+  "message": "Expected <Fixture, 2 span nodes found> to have className of \".baux\" but instead found \"baux\"",
+  "negatedMessage": "Expected <Fixture, 2 span nodes found> not to contain \".baux\" for it\'s classname",
   "pass": true,
 }
 `;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveStyle--tests.js.snap
@@ -1,7 +1,7 @@
 exports[`toHaveStyle mount provides contextual information for the message (mount) 1`] = `
 Object {
-  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m"100%"[33m[39m",
-  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m"100%"[33m[39m",
+  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m\"100%\"[33m[39m",
+  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m\"100%\"[33m[39m",
 }
 `;
 
@@ -19,29 +19,29 @@ Object {
 exports[`toHaveStyle mount provides the right info when a specific key doesn't exist 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div style="width: 0px;"></div>",
+    "actual": "<div style=\"width: 0px;\"></div>",
   },
-  "message": "Expected <div> component to have a style key of "height" but it did not.",
-  "negatedMessage": "Expected <div> component not to have a style key of "height" but it did.",
+  "message": "Expected <div> component to have a style key of \"height\" but it did not.",
+  "negatedMessage": "Expected <div> component not to have a style key of \"height\" but it did.",
   "pass": false,
 }
 `;
 
-exports[`toHaveStyle mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> component style values to be different for key "height", but they weren't"`;
+exports[`toHaveStyle mount returns the message with the proper fail verbage (mount) 1`] = `"Expected <span> component style values to be different for key \"height\", but they weren\'t"`;
 
-exports[`toHaveStyle mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> component style values to match for key "height", but they didn't"`;
+exports[`toHaveStyle mount returns the message with the proper pass verbage (mount) 1`] = `"Expected <span> component style values to match for key \"height\", but they didn\'t"`;
 
 exports[`toHaveStyle shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m"100%"[33m[39m",
-  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m"100%"[33m[39m",
+  "actual": "Actual: [33mheight[39m[90m:[39m [33m[90m\"100%\"[33m[39m",
+  "expected": "Expected: [33mheight[39m[90m:[39m [33m[90m\"100%\"[33m[39m",
 }
 `;
 
 exports[`toHaveStyle shallow provides the right info for if there is no style prop 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div></div>",
+    "actual": "<div />",
   },
   "message": "Expected <div> component to have a style prop but it did not.",
   "negatedMessage": "Expected <div> component not to have a style prop but it did.",
@@ -52,14 +52,14 @@ Object {
 exports[`toHaveStyle shallow provides the right info when a specific key doesn't exist 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div style="width:0px;"></div>",
+    "actual": "<div style={{...}} />",
   },
-  "message": "Expected <div> component to have a style key of "height" but it did not.",
-  "negatedMessage": "Expected <div> component not to have a style key of "height" but it did.",
+  "message": "Expected <div> component to have a style key of \"height\" but it did not.",
+  "negatedMessage": "Expected <div> component not to have a style key of \"height\" but it did.",
   "pass": false,
 }
 `;
 
-exports[`toHaveStyle shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> component style values to be different for key "height", but they weren't"`;
+exports[`toHaveStyle shallow returns the message with the proper fail verbage (shallow) 1`] = `"Expected <span> component style values to be different for key \"height\", but they weren\'t"`;
 
-exports[`toHaveStyle shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> component style values to match for key "height", but they didn't"`;
+exports[`toHaveStyle shallow returns the message with the proper pass verbage (shallow) 1`] = `"Expected <span> component style values to match for key \"height\", but they didn\'t"`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveTagName--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveTagName--tests.js.snap
@@ -41,7 +41,7 @@ Object {
 
 exports[`toHaveTagName shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "<a id=\"a\"></a>",
+  "actual": "<a id=\"a\" />",
 }
 `;
 
@@ -61,7 +61,7 @@ exports[`toHaveTagName shallow returns the message with the proper pass verbage 
 exports[`toHaveTagName shallow works on composite functions 1`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\"span\"></span><span></span><a id=\"a\"></a></div>",
+    "actual": "<div><span id=\"span\" /><span /><a id=\"a\" /></div>",
   },
   "message": "Expected <Fixture> node to equal (using ===) type \"Fixture\" but it is a \"div\".",
   "negatedMessage": "Expected <Fixture> node not to equal (using ===) type \"Fixture\" but it is that type.",
@@ -72,7 +72,7 @@ Object {
 exports[`toHaveTagName shallow works on composite functions 2`] = `
 Object {
   "contextualInformation": Object {
-    "actual": "<div><span id=\"span\"></span><span></span><a id=\"a\"></a></div>",
+    "actual": "<div><span id=\"span\" /><span /><a id=\"a\" /></div>",
   },
   "message": "Expected <Fixture> node to equal (using ===) type \"a\" but it is a \"div\".",
   "negatedMessage": "Expected <Fixture> node not to equal (using ===) type \"a\" but it is that type.",

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toHaveValue--tests.js.snap
@@ -10,7 +10,7 @@ exports[`toHaveValue mount returns the message with the proper pass verbage (mou
 
 exports[`toHaveValue shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "<input value=\"test\"/>",
+  "actual": "<input defaultValue=\"test\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchSelector--tests.js.snap
@@ -10,7 +10,7 @@ exports[`toMatchSelector mount returns the message with the proper pass verbage 
 
 exports[`toMatchSelector shallow provides contextual information for the message (shallow) 1`] = `
 Object {
-  "actual": "<span id=\"child\" class=\"foo\"></span>",
+  "actual": "<span id=\"child\" className=\"foo\" />",
 }
 `;
 

--- a/packages/enzyme-matchers/src/assertions/toBeDisabled.js
+++ b/packages/enzyme-matchers/src/assertions/toBeDisabled.js
@@ -8,6 +8,7 @@
 
 import type { Matcher } from '../../../../types/Matcher';
 import type { EnzymeObject } from '../../../../types/EnzymeObject';
+import html from '../utils/html';
 import getNodeName from '../utils/name';
 import single from '../utils/single';
 
@@ -19,7 +20,7 @@ function toBeDisabled(enzymeWrapper:EnzymeObject) : Matcher {
     message: `Expected node (${getNodeName(enzymeWrapper)}) to be "disabled" but it wasn't.`,
     negatedMessage: `Expected node (${getNodeName(enzymeWrapper)}) not to be "disabled" but it was`,
     contextualInformation: {
-      expected: `Node HTML output: ${enzymeWrapper.html()}`,
+      expected: `Node HTML output: ${html(enzymeWrapper)}`,
     },
   };
 }

--- a/packages/enzyme-matchers/src/assertions/toContainReact.js
+++ b/packages/enzyme-matchers/src/assertions/toContainReact.js
@@ -19,8 +19,8 @@ function toContainReact(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matc
 
   return {
     pass,
-    message: `Expected <${getNodeName(enzymeWrapper)}> to contain ${wrappedInstance.html()} but it was not found.`,
-    negatedMessage: `Expected <${getNodeName(enzymeWrapper)}> not to contain ${wrappedInstance.html()} but it does.`,
+    message: `Expected <${getNodeName(enzymeWrapper)}> to contain ${html(wrappedInstance)} but it was not found.`,
+    negatedMessage: `Expected <${getNodeName(enzymeWrapper)}> not to contain ${html(wrappedInstance)} but it does.`,
     contextualInformation: {
       actual: `HTML Output of <${getNodeName(enzymeWrapper)}>:\n ${html(enzymeWrapper)}`,
     },

--- a/packages/enzyme-matchers/src/utils/__tests__/html.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/html.test.js
@@ -4,7 +4,7 @@ const html = require('../html');
 
 describe('html', () => {
   const inputStrings = {
-    shallow: '<input/>',
+    shallow: '<input />',
     mount: '<input>',
   };
 

--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -2,6 +2,7 @@ import instance from './instance';
 /* eslint-disable no-console */
 const noop = () => {};
 const error = console.error;
+const SHALLOW_WRAPPER_CONSTRUCTOR = 'ShallowWrapper';
 
 function mapWrappersHTML(wrapper) : string {
   return wrapper.nodes.map(node => {
@@ -33,6 +34,10 @@ export default function printHTMLForWrapper(wrapper) : string {
       return '[empty set]';
     }
     case 1: {
+      if (wrapper.constructor.name === SHALLOW_WRAPPER_CONSTRUCTOR) {
+        return wrapper.debug().replace(/\n/g, '');
+      }
+
       return wrapper.html();
     }
     default: {

--- a/packages/jest-enzyme/src/__failing_tests__/toContainReact.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toContainReact.test.js
@@ -1,4 +1,4 @@
-const { shallow } = require('enzyme');
+const { shallow, mount } = require('enzyme');
 const React = require('react');
 
 describe('failing test', () => {
@@ -6,21 +6,25 @@ describe('failing test', () => {
     <div><i /></div>
   );
 
-  it('fails toContainReact', () => {
-    expect(
-      shallow(<Fixture />)
-    ).toContainReact(<b />);
-  });
+  [shallow, mount].forEach(builder => {
+    describe(builder.name, () => {
+      it('fails toContainReact', () => {
+        expect(
+          builder(<Fixture />)
+        ).toContainReact(<b />);
+      });
 
-  it('fails NOT toContainReact', () => {
-    expect(
-      shallow(<Fixture />)
-    ).not.toContainReact(<i />);
-  });
+      it('fails NOT toContainReact', () => {
+        expect(
+          builder(<Fixture />)
+        ).not.toContainReact(<i />);
+      });
 
-  it('fails NOT toContainReact multiple nodes', () => {
-    expect(
-      shallow(<div><span /><span foo /></div>).find('span')
-    ).toContainReact(<span foo={false} />);
+      it('fails NOT toContainReact multiple nodes', () => {
+        expect(
+          builder(<div><span /><span foo /></div>).find('span')
+        ).toContainReact(<span foo={false} />);
+      });
+    });
   });
 });


### PR DESCRIPTION
As mentioned in https://github.com/blainekasten/enzyme-matchers/issues/65, `.html()` is being called for shallow wrappers to generate things like `contextualInformation`. The fix is to replace that with `.debug()` for those cases.