### PR TITLE
Uprev enzyme-matchers dependency

### DIFF
--- a/packages/jasmine-enzyme/package.json
+++ b/packages/jasmine-enzyme/package.json
@@ -42,7 +42,7 @@
     "enzyme": "1.x || 2.x"
   },
   "dependencies": {
-    "enzyme-matchers": "^2.1.2"
+    "enzyme-matchers": "^3.0.0"
   },
   "jest": {
     "testPathDirs": [

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -46,7 +46,7 @@
     "jest": ">=19.0.0"
   },
   "dependencies": {
-    "enzyme-matchers": "^2.1.2",
+    "enzyme-matchers": "^3.0.0",
     "enzyme-to-json": "^1.5.0"
   },
   "jest": {


### PR DESCRIPTION
Jest package was not installing the latest enzyme-matchers so I think this is the fix.