### PR TITLE
Migrating React.PropTypes to prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ class User extends React.Component {
 }
 
 User.propTypes = {
-  index: React.PropTypes.number.isRequired
+  index: PropTypes.number.isRequired
 }
 
 class Fixture extends React.Component {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "verbose": true
   },
   "dependencies": {
-    "babel-preset-stage-2": "^6.18.0"
+    "babel-preset-stage-2": "^6.18.0",
+    "prop-types": "^15.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-react": "^4.3.0",
     "jest-cli": "^19.0.0",
     "lerna": "2.0.0-beta.30",
+    "prop-types": "^15.5.6",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
@@ -65,7 +66,6 @@
     "verbose": true
   },
   "dependencies": {
-    "babel-preset-stage-2": "^6.18.0",
-    "prop-types": "^15.5.6"
+    "babel-preset-stage-2": "^6.18.0"
   }
 }

--- a/packages/enzyme-matchers/src/assertions/__tests__/toContainReact--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toContainReact--tests.js
@@ -1,5 +1,6 @@
 const { shallow } = require('enzyme');
 const React = require('react');
+import PropTypes from 'prop-types';
 
 const toContainReact = require('../toContainReact');
 
@@ -10,7 +11,7 @@ function User(props) {
 }
 
 User.propTypes = {
-  index: React.PropTypes.number.isRequired,
+  index: PropTypes.number.isRequired,
 };
 
 function Fixture() {

--- a/packages/enzyme-matchers/src/assertions/__tests__/toHaveProp--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toHaveProp--tests.js
@@ -1,5 +1,6 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
+import PropTypes from 'prop-types';
 
 const toHaveProp = require('../toHaveProp');
 
@@ -15,11 +16,11 @@ function User(props) {
 }
 
 User.propTypes = {
-  name: React.PropTypes.string,
-  email: React.PropTypes.string,
-  arrayProp: React.PropTypes.array,
-  objectProp: React.PropTypes.object,
-  falsy: React.PropTypes.bool,
+  name: PropTypes.string,
+  email: PropTypes.string,
+  arrayProp: PropTypes.array,
+  objectProp: PropTypes.object,
+  falsy: PropTypes.bool,
 };
 
 const fn = () => {};

--- a/packages/jasmine-enzyme/spec/fixtures/toContainReact.fixture.js
+++ b/packages/jasmine-enzyme/spec/fixtures/toContainReact.fixture.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.User = User;
 exports.Fixture = Fixture;
 var React = require('react');
+var PropTypes = require('prop-types');
 
 function User(props) {
   return React.createElement(
@@ -17,7 +18,7 @@ function User(props) {
 }
 
 User.propTypes = {
-  index: React.PropTypes.number.isRequired
+  index: PropTypes.number.isRequired
 };
 
 function Fixture() {

--- a/packages/jasmine-enzyme/spec/fixtures/toHaveProp.fixture.js
+++ b/packages/jasmine-enzyme/spec/fixtures/toHaveProp.fixture.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = Fixture;
 var React = require('react');
+var PropTypes = require('prop-types');
 
 function User(props) {
   return React.createElement(
@@ -15,7 +16,7 @@ function User(props) {
 }
 
 User.propTypes = {
-  name: React.PropTypes.string
+  name: PropTypes.string
 };
 
 function Fixture() {

--- a/packages/jest-enzyme/src/__failing_tests__/toBeChecked.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toBeChecked.test.js
@@ -5,7 +5,7 @@ describe('failing test', () => {
   [shallow, mount].forEach(builder => {
     describe(builder.name, () => {
       const Fixture = (props) => <input defaultChecked={props.defaultChecked} />;
-      Fixture.propTypes = { defaultChecked: React.PropTypes.bool };
+      Fixture.propTypes = { defaultChecked: PropTypes.bool };
 
       it('fails toBeChecked', () => {
         expect(

--- a/packages/jest-enzyme/src/__failing_tests__/toBeDisabled.test.js
+++ b/packages/jest-enzyme/src/__failing_tests__/toBeDisabled.test.js
@@ -5,7 +5,7 @@ describe('failing test', () => {
   [shallow, mount].forEach(builder => {
     describe(builder.name, () => {
       const Fixture = (props) => <input disabled={props.disabled} />;
-      Fixture.propTypes = { disabled: React.PropTypes.bool };
+      Fixture.propTypes = { disabled: PropTypes.bool };
 
       it('fails toBeDisabled', () => {
         expect(


### PR DESCRIPTION
Using React.PropTypes is raising warnings, migrating React.PropTypes to PropTypes removed those warnings. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes