### PR TITLE
update snapshot for failing test

### DIFF
--- a/packages/enzyme-matchers/src/utils/__tests__/__snapshots__/single.test.js.snap
+++ b/packages/enzyme-matchers/src/utils/__tests__/__snapshots__/single.test.js.snap
@@ -3,8 +3,8 @@
 exports[`single gives a useful message 1`] = `
 Object {
   "contextualInformation": Object {},
-  "message": " must be called on a single node, not multiple nodes.",
-  "negatedMessage": " must be called on a single node, not multiple nodes.",
+  "message": "mockConstructor must be called on a single node, not multiple nodes.",
+  "negatedMessage": "mockConstructor must be called on a single node, not multiple nodes.",
   "pass": false,
 }
 `;


### PR DESCRIPTION
Fixes https://github.com/blainekasten/enzyme-matchers/issues/87 by updating the jest snapshot.