### PR TITLE
fix ReferenceError that occurs when console is not defined

### DIFF
--- a/packages/enzyme-matchers/src/utils/getConsoleObject.js
+++ b/packages/enzyme-matchers/src/utils/getConsoleObject.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-console */
+export default function getConsoleObject() : Object {
+  try {
+    return console;
+  } catch (e) {
+    // If no global console object is available, set consoleObject to a dummy object.
+    return {};
+  }
+}

--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -1,7 +1,14 @@
 import instance from './instance';
 /* eslint-disable no-console */
+let consoleObject;
+try {
+  consoleObject = console;
+} catch (e) {
+  // If no global console object is available, set consoleObject to a dummy object.
+  consoleObject = {};
+}
 const noop = () => {};
-const error = console.error;
+const error = consoleObject.error;
 const SHALLOW_WRAPPER_CONSTRUCTOR = 'ShallowWrapper';
 
 function mapWrappersHTML(wrapper) : string {
@@ -9,11 +16,11 @@ function mapWrappersHTML(wrapper) : string {
     const inst = instance(node);
     const type = node.type || inst._tag;
 
-    console.error = noop;
+    consoleObject.error = noop;
     const { children, ...props } = node.props
       ? node.props
       : inst._currentElement.props;
-    console.error = error;
+    consoleObject.error = error;
 
     const transformedProps = Object.keys(props).map(key => `${key}="${props[key]}"`);
     let stringifiedNode = `<${type} ${transformedProps.join(' ')}`;

--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -1,12 +1,7 @@
 import instance from './instance';
-/* eslint-disable no-console */
-let consoleObject;
-try {
-  consoleObject = console;
-} catch (e) {
-  // If no global console object is available, set consoleObject to a dummy object.
-  consoleObject = {};
-}
+import getConsoleObject from './getConsoleObject';
+
+const consoleObject = getConsoleObject();
 const noop = () => {};
 const error = consoleObject.error;
 const SHALLOW_WRAPPER_CONSTRUCTOR = 'ShallowWrapper';


### PR DESCRIPTION
Fixes https://github.com/blainekasten/enzyme-matchers/issues/91. The only way to safely reference a variable that may be undeclared is in a try/catch.