### PR TITLE
expose matchers directly from jasmine-enzyme

### DIFF
--- a/packages/jasmine-enzyme/src/index.js
+++ b/packages/jasmine-enzyme/src/index.js
@@ -11,7 +11,7 @@ import enzymeMatchers from 'enzyme-matchers';
 
 declare var jest:Object;
 
-export default function jasmineEnzyme() : void {
+function jasmineEnzyme() : void {
   // Migration step for moving people from jasmine-enzyme
   // to jest-enzyme
   if (typeof jest !== 'undefined') {
@@ -29,3 +29,13 @@ export default function jasmineEnzyme() : void {
     });
   });
 }
+
+// Also expose enzymeMatchers directly so that the matchers can be added on a per-spec basis
+// instead of globally on the jasmine object. This also supports older versions of jasmine where
+// jasmine.addMatchers isn't defined and matchers must be added to the spec in a beforeEach().
+//
+// Add enzymeMatchers as an expando property onto the jasmineEnzyme function for backwards
+// compatibility with previous versions of jasmine-enzyme.
+jasmineEnzyme.enzymeMatchers = enzymeMatchers;
+
+export default jasmineEnzyme;


### PR DESCRIPTION
Fixes https://github.com/blainekasten/enzyme-matchers/issues/93.

This fix is backwards-compatible. A more ideal fix would be to use:

```
export {
    jasmineEnzyme: ...,
    enzymeMatchers: ...
}
```

However, I'm preferring the backwards-compat one so that upgrading to newer versions of this lib don't require changes.