### PR TITLE
Release3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+3.2.0
+=====
+  * Publish types for Flow integration support
+  * Fix an issue where `console` may not be available in certain environments
+  * Expose matchers directly for `jasmine-enzyme`
+    * This is particularily benefecial for jasmine v1 users
+    * Access if found at `jasmineEnzyme.enzymeMatchers`
+  * Fix an issue with using shallow wrappers when running tests in IE
+
 3.1.1
 =====
   * Fix a bug when running tests in IE

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.0.0-beta.30",
-  "version": "3.1.1"
+  "version": "3.2.0"
 }

--- a/packages/enzyme-matchers/package.json
+++ b/packages/enzyme-matchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enzyme-matchers",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Testing Matchers for Enzyme",
   "main": "lib/index.js",
   "homepage": "https://github.com/blainekasten/enzyme-matchers/packages/enzyme-matchers#readme",

--- a/packages/jasmine-enzyme/package.json
+++ b/packages/jasmine-enzyme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-enzyme",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Jasmine assertions for enzyme",
   "main": "lib/index.js",
   "homepage": "https://github.com/blainekasten/enzyme-matchers/packages/jasmine-enzyme#readme",
@@ -43,7 +43,7 @@
     "enzyme": "1.x || 2.x"
   },
   "dependencies": {
-    "enzyme-matchers": "^3.1.1"
+    "enzyme-matchers": "^3.2.0"
   },
   "jest": {
     "testPathDirs": [

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-enzyme",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Testing Matchers for Enzyme",
   "main": "lib/index.js",
   "author": "Blaine Kasten <blainekasten@gmail.com>",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@types/react": "^15.0.22",
-    "enzyme-matchers": "^3.1.1",
+    "enzyme-matchers": "^3.2.0",
     "enzyme-to-json": "^1.5.0"
   },
   "jest": {


### PR DESCRIPTION
  * Publish types for Flow integration support
  * Fix an issue where `console` may not be available in certain environments
  * Expose matchers directly for `jasmine-enzyme`
    * This is particularily benefecial for jasmine v1 users
    * Access if found at `jasmineEnzyme.enzymeMatchers`
  * Fix an issue with using shallow wrappers when running tests in IE
