### PR TITLE
Only add used files to npm package

### DIFF
--- a/packages/enzyme-matchers/package.json
+++ b/packages/enzyme-matchers/package.json
@@ -15,7 +15,6 @@
     "build": "babel src --out-dir lib --ignore tests"
   },
   "files": [
-    "src",
     "lib",
     "types"
   ],

--- a/packages/jasmine-enzyme/package.json
+++ b/packages/jasmine-enzyme/package.json
@@ -16,7 +16,6 @@
     "build": "babel src --out-dir lib --ignore tests"
   },
   "files": [
-    "src",
     "lib",
     "types"
   ],

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -16,7 +16,6 @@
     "build": "babel src --out-dir lib --ignore tests"
   },
   "files": [
-    "src",
     "lib",
     "types"
   ],


### PR DESCRIPTION
`src/` files get compiled to the `lib/` folder. As such, files inside the src are unnecessary to the npm package.

This causes issues with Flowtypes as explained in #77