### PR TITLE
Add explicit return types for all matchers

### DIFF
--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -14,9 +14,9 @@ declare namespace jest {
         toHaveState(stateKey: string, stateValue?: any): void;
         toHaveStyle(styleKey: string, styleValue?: any): void;
         toHaveTagName(tagName: string): void;
-        toHaveText(text: string);
-        toIncludeText(text: string);
-        toHaveValue(value: any);
-        toMatchSelector(selector: string);
+        toHaveText(text: string): void;
+        toIncludeText(text: string): void;
+        toHaveValue(value: any): void;
+        toMatchSelector(selector: string): void;
     }
 }


### PR DESCRIPTION
Without explicit return types, these matchers have an inferred type of `any`