### PR TITLE
Fix implicit any return type for jest TypeScript

### DIFF
--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -14,9 +14,9 @@ declare namespace jest {
         toHaveState(stateKey: string, stateValue?: any): void;
         toHaveStyle(styleKey: string, styleValue?: any): void;
         toHaveTagName(tagName: string): void;
-        toHaveText(text: string);
-        toIncludeText(text: string);
-        toHaveValue(value: any);
-        toMatchSelector(selector: string);
+        toHaveText(text: string): void;
+        toIncludeText(text: string): void;
+        toHaveValue(value: any): void;
+        toMatchSelector(selector: string): void;
     }
 }


### PR DESCRIPTION
When TypeScript is configured to not allow implicit any's, the
compilation fails with this error:

```
/path/to/project/node_modules/jest-enzyme/src/index.d.ts
[1] (17,9): error TS7010: 'toHaveText', which lacks return-type annotation, implicitly has an 'any' return type.
```

By adding the void return type to these definitions like we've done on
the others. It resolves this issue.