### PR TITLE
Avoid caching original `console.error`

### DIFF
--- a/packages/enzyme-matchers/src/utils/html.js
+++ b/packages/enzyme-matchers/src/utils/html.js
@@ -7,7 +7,6 @@ import type { EnzymeObject } from '../types';
 
 const consoleObject = getConsoleObject();
 const noop = () => {};
-const error = consoleObject.error;
 
 
 function mapWrappersHTML(wrapper: EnzymeObject): Array<string> {
@@ -15,6 +14,7 @@ function mapWrappersHTML(wrapper: EnzymeObject): Array<string> {
     const inst = instance(node);
     const type = node.type || inst._tag;
 
+    const error = consoleObject.error;
     consoleObject.error = noop;
     const { children, ...props } = node.props
       ? node.props


### PR DESCRIPTION
- only cache before switching to a no-op

Using the original `console.error` can be problematic in codebases with a modified `console.error`. e.g. spied `console.error` for test assertions

---

This is an issue in our codebase. We spy on `console.error` at the start of each test and assert 0 calls at the end of the tests. Going through this code path removes this functionality because it is restoring it to the original `console.error` reference.