### PR TITLE
Fix typescript type of toContainReact argument

### DIFF
--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace jest {
         toBeDisabled(): void;
         toBeEmpty(): void;
         toBePresent(): void;
-        toContainReact(component: React.Component<any, any>): void;
+        toContainReact(component: ReactElement<any>): void;
         toHaveClassName(className: string): void;
         toHaveHTML(html: string): void;
         toHaveProp(propKey: string, propValue?: any): void;


### PR DESCRIPTION
The documentation suggests that it takes a rendered element, not just the component class.

Without the fix:

```
  const child = <div id="child" />
  const element = enzyme.shallow(<div>{child}</div>);
  expect(element).toContainReact(child);
```
```
Argument of type 'Element' is not assignable to parameter of type 'Component<any, any>'.
  Property 'setState' is missing in type 'Element'.'
```

With the fix:
Compiles and runs!