### PR TITLE
Remove target from babel-preset-env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,6 @@
 
 const presets = [
-  ['env', {
-    targets: {
-      node: 4,
-    },
-  }],
+  'env',
   'react',
 ];
 


### PR DESCRIPTION
https://github.com/blainekasten/enzyme-matchers/issues/123

I noticed the tests weren't passing even with a clean pull, it seems mostly related to spacing changes in the snapshots. I could do a separate pull request for those if you'd like, just want to confirm that it's not just me.