### PR TITLE
fix type definition for jest-enzyme

### DIFF
--- a/packages/jest-enzyme/src/index.d.ts
+++ b/packages/jest-enzyme/src/index.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="react" />
 
 declare namespace jest {
-    interface Matchers {
+    interface Matchers<R> {
         toBeChecked(): void;
         toBeDisabled(): void;
         toBeEmpty(): void;
         toBePresent(): void;
-        toContainReact(component: ReactElement<any>): void;
+        toContainReact(component: React.ReactElement<any>): void;
         toHaveClassName(className: string): void;
         toHaveHTML(html: string): void;
         toHaveProp(propKey: string, propValue?: any): void;
@@ -17,7 +17,7 @@ declare namespace jest {
         toHaveText(text: string): void;
         toIncludeText(text: string): void;
         toHaveValue(value: any): void;
-        toMatchElement(element: ReactElement<any>): void;
+        toMatchElement(element: React.ReactElement<any>): void;
         toMatchSelector(selector: string): void;
     }
 }


### PR DESCRIPTION
make type definition more accurate and comply with jest's type definition.

right now, when I try to define my own matcher, because of this type definition, I get an error: `All declarations of 'Matchers' must have identical type parameters`. Even though this doesn't use the R parameter, because all interfaces must have same type, this file gives everyone a hard time :)