### PR TITLE
Jest 21 expects result.message to always be a function

### DIFF
--- a/packages/jest-enzyme/src/index.js
+++ b/packages/jest-enzyme/src/index.js
@@ -25,21 +25,21 @@ beforeEach(() => {
       [matcherKey](wrapper, ...args) {
         const result = enzymeMatchers[matcherKey].call(this, wrapper, ...args);
 
-        if (this.isNot) {
-          result.message = result.negatedMessage;
-        }
+        let message = this.isNot ? result.negatedMessage : result.message;
 
         if (result.contextualInformation.expected) {
-          result.message += `\n${this.utils.RECEIVED_COLOR(
+          message += `\n${this.utils.RECEIVED_COLOR(
             result.contextualInformation.expected
           )}`;
         }
 
         if (result.contextualInformation.actual) {
-          result.message += `\n${this.utils.EXPECTED_COLOR(
+          message += `\n${this.utils.EXPECTED_COLOR(
             result.contextualInformation.actual
           )}`;
         }
+
+        result.message = () => message;
 
         return result;
       },


### PR DESCRIPTION
When using `jest-enzyme` with pre-release versions of Jest, failed assertions don't display correctly. Instead of seeing a useful description of the failed assertion, we get `TypeError: message is not a function`.

Returning a function remains compatible with older versions of Jest.

ref: https://github.com/facebook/jest/issues/3921
ref: https://github.com/facebook/jest/pull/3972