### PR TITLE
Update enzyme-to-json to support React 16.2

### DIFF
--- a/packages/jest-enzyme/package-lock.json
+++ b/packages/jest-enzyme/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "jest-enzyme",
+  "version": "4.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/react": {
+      "version": "16.0.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.31.tgz",
+      "integrity": "sha512-ft7OuDGUo39e+9LGwUewf2RyEaNBOjWbHUmD5bzjNuSuDabccE/1IuO7iR0dkzLjVUKxTMq69E+FmKfbgBcfbQ==",
+      "dev": true
+    },
+    "enzyme-to-json": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz",
+      "integrity": "sha512-d8IfzVpwunct+bw6uWujjHKtskyLwWGKkAguouAdTMNTaTmoC0Y0N0mWpeOq+bFDM4YljRXmBRIsO6QNWrlZzA==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    }
+  }
+}

--- a/packages/jest-enzyme/package.json
+++ b/packages/jest-enzyme/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "enzyme-matchers": "^4.0.1",
-    "enzyme-to-json": "^3.0.0"
+    "enzyme-to-json": "^3.3.0"
   },
   "jest": {
     "roots": [

--- a/packages/jest-enzyme/yarn.lock
+++ b/packages/jest-enzyme/yarn.lock
@@ -12,15 +12,15 @@ deep-equal-ident@^1.1.1:
   dependencies:
     lodash.isequal "^3.0"
 
-enzyme-matchers@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/enzyme-matchers/-/enzyme-matchers-4.0.0.tgz#3158166a5004f289895d203f58372bb7867a88e5"
+enzyme-matchers@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-matchers/-/enzyme-matchers-4.0.1.tgz#f3fb5e5e5e5ec9a19144d172605433fc7e9d9f5a"
   dependencies:
     deep-equal-ident "^1.1.1"
 
-enzyme-to-json@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.1.1.tgz#b161b4ef34f12d9e25af8e24f2a0cab68fb2fb54"
+enzyme-to-json@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz#553e23a09ffb4b0cf09287e2edf9c6539fddaa84"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
`enzyme-to-json` was updated to `3.3.0` to support fragments (https://github.com/adriantoine/enzyme-to-json/pull/90) when serializing components. Since `jest-enzyme` uses it, we need to update that dependency.