### PR TITLE
Lint configuration and lint error fixes discussed in #181

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,16 @@ machine:
   node:
     version: 8.0.0
 
+dependencies:
+  override:
+    - yarn
+
 test:
   pre:
     - lerna run lint
+  override:
+    - yarn test
 
 dependencies:
-  post: 
+  post:
     - lerna bootstrap

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "^2.7.0",
+    "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.3.0",
     "flow-bin": "^0.49.1",
     "flow-copy-source": "^1.2.0",

--- a/packages/enzyme-matchers/src/assertions/toHaveProp.js
+++ b/packages/enzyme-matchers/src/assertions/toHaveProp.js
@@ -12,6 +12,7 @@ import name from '../utils/name';
 import stringify from '../utils/stringify';
 import single from '../utils/single';
 
+/* eslint-disable prefer-rest-params */
 function toHaveProp(
   enzymeWrapper: EnzymeObject,
   propKey: string,

--- a/packages/enzyme-matchers/src/assertions/toHaveState.js
+++ b/packages/enzyme-matchers/src/assertions/toHaveState.js
@@ -12,6 +12,7 @@ import name from '../utils/name';
 import stringify from '../utils/stringify';
 import single from '../utils/single';
 
+/* eslint-disable prefer-rest-params */
 function toHaveState(
   enzymeWrapper: EnzymeObject,
   stateKey: string,

--- a/packages/enzyme-matchers/src/utils/__tests__/name.test.js
+++ b/packages/enzyme-matchers/src/utils/__tests__/name.test.js
@@ -24,21 +24,23 @@ describe('getNodeName', () => {
       });
 
       it('gives a useful string when given multiple same type nodes', () => {
-        const Fixture = () =>
+        const Fixture = () => (
           <div>
             <i />
             <i />
-          </div>;
+          </div>
+        );
 
         expect(name(builder(<Fixture />).find('i'))).toBe('2 i nodes found');
       });
 
       it('gives a useful string when given multiple mixed nodes', () => {
-        const Fixture = () =>
+        const Fixture = () => (
           <div>
             <i className="foo" />
             <b className="foo" />
-          </div>;
+          </div>
+        );
 
         expect(name(builder(<Fixture />).find('.foo'))).toBe(
           '2 mixed nodes found'
@@ -55,9 +57,6 @@ describe('getNodeName', () => {
 
         const arrayOf2 = wrapper.find('i');
         const arrayOfNone = wrapper.find('b');
-
-        const nodeName =
-          builder === mount ? '2 i nodes found' : '2 i nodes found'; // Enzyme 3 bug
 
         expect(name(arrayOfNone)).toBe('[empty set]');
         expect(name(arrayOf2)).toBe('2 i nodes found');

--- a/packages/enzyme-matchers/src/utils/name.js
+++ b/packages/enzyme-matchers/src/utils/name.js
@@ -76,8 +76,6 @@ export default function getNameFromArbitraryWrapper(wrapper: Object): string {
       const nodeTypes: string =
         nodeTypeList.length === 1 ? nodeTypeList[0] : 'mixed';
 
-      const root = wrapper.first().parents();
-
       return `${nodeCount} ${nodeTypes} nodes found`;
     }
   }


### PR DESCRIPTION
- Added back lint configuration at version it was before it was removed
- Removed 2 unused variables
- Added eslint-disable comments to allow use of 'arguments' instead of rest parameters for these scenarios (went with block level disable because disabling at the line level did not work. On commit, the comments were automatically moved down to the next line.)
- Other changes happened automatically on commit

I'm still learning how all this works... Feedback welcome.