### PR TITLE
Update toHaveText docs to clarify exact matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ expect(wrapper.find('#span')).not.toHaveTagName('div');
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
-Assert that the wrapper has the provided text:
+Assert that the wrapper's text matches the provided text exactly, using a strict comparison (`===`).
 
 ```js
 function Fixture() {


### PR DESCRIPTION
Previously, the difference between 'has-text' and 'includes-text' wasn't clear without trying each function.  This updates the docs for `toHaveText` to highlight it is matching *exactly*.