### PR TITLE
ignore props by default for toMatchElement()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This library supports several testing frameworks including [Jest](https://github
 * [toHaveText()](#tohavetexttextstring)
 * [toIncludeText()](#toincludetexttextstring)
 * [toHaveValue()](#tohavevaluevalueany)
-* [toMatchElement()](#tomatchelementreactinstanceobject)
+* [toMatchElement()](#tomatchelementreactinstanceobject-optionsany)
 * [toMatchSelector()](#tomatchselectorselectorstring)
 
 _Other_
@@ -455,13 +455,13 @@ expect(wrapper.find('input').at(0)).toHaveValue('test');
 expect(wrapper.find('input').at(1)).toHaveValue('bar');
 ```
 
-#### `toMatchElement(reactInstance:Object)`
+#### `toMatchElement(reactInstance:Object, options:any)`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
-Assert the wrapper matches the provided react instance. This is a matcher form of Enzyme's wrapper.matchesElement(), which returns a bool with no indication of what caused a failed match. This matcher includes the actual and expected debug trees as contextual information when it fails. NOTE: The semantics are slightly different than enzyme's wrapper.matchesElement(), which ignores props. This matcher does consider props when comparing the actual to the expected values.
+Assert the wrapper matches the provided react instance. This is a matcher form of Enzyme's wrapper.matchesElement(), which returns a bool with no indication of what caused a failed match. This matcher includes the actual and expected debug trees as contextual information when it fails. Like matchesElement(), props are ignored. If you want to compare prop values as well, pass `{ ignoreProps: false }` as options. Uses enzyme's [debug()](http://airbnb.io/enzyme/docs/api/ShallowWrapper/debug.html) under the hood and compares debug strings, which makes for a human readable diff when expects fail.
 
 Example:
 
@@ -477,8 +477,10 @@ function Fixture() {
 const wrapper = shallow(<Fixture />); // mount/render/shallow when applicable
 
 expect(wrapper).toMatchElement(<Fixture />);
+expect(wrapper.find('span')).toMatchElement(<span />);
 expect(wrapper.find('span')).toMatchElement(
-  <span id="foo" className="bar" />
+  <span id="foo" className="bar" />,
+  { ignoreProps: false }
 );
 expect(wrapper).not.toMatchElement(<div />);
 ```

--- a/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchElement--tests.js.snap
+++ b/packages/enzyme-matchers/src/assertions/__tests__/__snapshots__/toMatchElement--tests.js.snap
@@ -5,13 +5,13 @@ Object {
   "actual": "Actual:
  <Fixture>
   <div>
-    <span id=\\"child\\" className=\\"foo\\" />
+    <span />
   </div>
 </Fixture>",
   "expected": "Expected:
  <Fixture>
   <div>
-    <span id=\\"child\\" className=\\"foo\\" />
+    <span />
   </div>
 </Fixture>",
 }
@@ -20,9 +20,9 @@ Object {
 exports[`toMatchElement mount provides contextual information for the message 2`] = `
 Object {
   "actual": "Actual:
- <span id=\\"child\\" className=\\"foo\\" />",
+ <span />",
   "expected": "Expected:
- <span id=\\"child\\" className=\\"foo\\" />",
+ <span />",
 }
 `;
 
@@ -31,11 +31,28 @@ Object {
   "actual": "Actual:
  <Fixture>
   <div>
-    <span id=\\"child\\" className=\\"foo\\" />
+    <span />
   </div>
 </Fixture>",
   "expected": "Expected:
  <div />",
+}
+`;
+
+exports[`toMatchElement mount provides contextual information for the message 4`] = `
+Object {
+  "actual": "Actual:
+ <Fixture>
+  <div>
+    <span id=\\"child\\" className=\\"foo\\" />
+  </div>
+</Fixture>",
+  "expected": "Expected:
+ <Fixture>
+  <div>
+    <span id=\\"child\\" className=\\"foo\\" />
+  </div>
+</Fixture>",
 }
 `;
 
@@ -45,21 +62,25 @@ exports[`toMatchElement mount returns the message with the proper fail verbage 2
 
 exports[`toMatchElement mount returns the message with the proper fail verbage 3`] = `"Did not expect actual value to match the expected value."`;
 
+exports[`toMatchElement mount returns the message with the proper fail verbage 4`] = `"Did not expect actual value to match the expected value."`;
+
 exports[`toMatchElement mount returns the message with the proper pass verbage 1`] = `"Expected actual value to match the expected value."`;
 
 exports[`toMatchElement mount returns the message with the proper pass verbage 2`] = `"Expected actual value to match the expected value."`;
 
 exports[`toMatchElement mount returns the message with the proper pass verbage 3`] = `"Expected actual value to match the expected value."`;
 
+exports[`toMatchElement mount returns the message with the proper pass verbage 4`] = `"Expected actual value to match the expected value."`;
+
 exports[`toMatchElement shallow provides contextual information for the message 1`] = `
 Object {
   "actual": "Actual:
  <div>
-  <span id=\\"child\\" className=\\"foo\\" />
+  <span />
 </div>",
   "expected": "Expected:
  <div>
-  <span id=\\"child\\" className=\\"foo\\" />
+  <span />
 </div>",
 }
 `;
@@ -67,9 +88,9 @@ Object {
 exports[`toMatchElement shallow provides contextual information for the message 2`] = `
 Object {
   "actual": "Actual:
- <span id=\\"child\\" className=\\"foo\\" />",
+ <span />",
   "expected": "Expected:
- <span id=\\"child\\" className=\\"foo\\" />",
+ <span />",
 }
 `;
 
@@ -77,10 +98,23 @@ exports[`toMatchElement shallow provides contextual information for the message 
 Object {
   "actual": "Actual:
  <div>
-  <span id=\\"child\\" className=\\"foo\\" />
+  <span />
 </div>",
   "expected": "Expected:
  <div />",
+}
+`;
+
+exports[`toMatchElement shallow provides contextual information for the message 4`] = `
+Object {
+  "actual": "Actual:
+ <div>
+  <span id=\\"child\\" className=\\"foo\\" />
+</div>",
+  "expected": "Expected:
+ <div>
+  <span id=\\"child\\" className=\\"foo\\" />
+</div>",
 }
 `;
 
@@ -90,8 +124,12 @@ exports[`toMatchElement shallow returns the message with the proper fail verbage
 
 exports[`toMatchElement shallow returns the message with the proper fail verbage 3`] = `"Did not expect actual value to match the expected value."`;
 
+exports[`toMatchElement shallow returns the message with the proper fail verbage 4`] = `"Did not expect actual value to match the expected value."`;
+
 exports[`toMatchElement shallow returns the message with the proper pass verbage 1`] = `"Expected actual value to match the expected value."`;
 
 exports[`toMatchElement shallow returns the message with the proper pass verbage 2`] = `"Expected actual value to match the expected value."`;
 
 exports[`toMatchElement shallow returns the message with the proper pass verbage 3`] = `"Expected actual value to match the expected value."`;
+
+exports[`toMatchElement shallow returns the message with the proper pass verbage 4`] = `"Expected actual value to match the expected value."`;

--- a/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement--tests.js
+++ b/packages/enzyme-matchers/src/assertions/__tests__/toMatchElement--tests.js
@@ -16,34 +16,43 @@ describe('toMatchElement', () => {
     describe(builder.name, () => {
       const wrapper = builder(<Fixture />);
       const truthyResults = toMatchElement(wrapper, <Fixture />);
-      const truthyResults2 = toMatchElement(
+      const truthyResultsMatchSpan = toMatchElement(
         wrapper.find('span'),
         <span id="child" className="foo" />
       );
       const falsyResults = toMatchElement(wrapper, <div />);
+      const truthyResultsIncludeProps = toMatchElement(wrapper, <Fixture />, {
+        ignoreProps: false,
+      });
 
       it('returns the pass flag properly', () => {
         expect(truthyResults.pass).toBeTruthy();
-        expect(truthyResults2.pass).toBeTruthy();
+        expect(truthyResultsMatchSpan.pass).toBeTruthy();
         expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResultsIncludeProps.pass).toBeTruthy();
       });
 
       it('returns the message with the proper pass verbage', () => {
         expect(truthyResults.message).toMatchSnapshot();
-        expect(truthyResults2.message).toMatchSnapshot();
+        expect(truthyResultsMatchSpan.message).toMatchSnapshot();
         expect(falsyResults.message).toMatchSnapshot();
+        expect(truthyResultsIncludeProps.message).toMatchSnapshot();
       });
 
       it('returns the message with the proper fail verbage', () => {
         expect(truthyResults.negatedMessage).toMatchSnapshot();
-        expect(truthyResults2.negatedMessage).toMatchSnapshot();
+        expect(truthyResultsMatchSpan.negatedMessage).toMatchSnapshot();
         expect(falsyResults.negatedMessage).toMatchSnapshot();
+        expect(truthyResultsIncludeProps.negatedMessage).toMatchSnapshot();
       });
 
       it('provides contextual information for the message', () => {
         expect(truthyResults.contextualInformation).toMatchSnapshot();
-        expect(truthyResults2.contextualInformation).toMatchSnapshot();
+        expect(truthyResultsMatchSpan.contextualInformation).toMatchSnapshot();
         expect(falsyResults.contextualInformation).toMatchSnapshot();
+        expect(
+          truthyResultsIncludeProps.contextualInformation
+        ).toMatchSnapshot();
       });
     });
   });

--- a/packages/enzyme-matchers/src/assertions/toMatchElement.js
+++ b/packages/enzyme-matchers/src/assertions/toMatchElement.js
@@ -7,13 +7,14 @@
  */
 
 import { shallow, mount } from 'enzyme';
-import type { EnzymeObject, Matcher } from '../types';
+import type { EnzymeObject, Matcher, ToMatchElementOptions } from '../types';
 import isShallowWrapper from '../utils/isShallowWrapper';
 import single from '../utils/single';
 
 function toMatchElement(
   actualEnzymeWrapper: EnzymeObject,
-  reactInstance: Object
+  reactInstance: Object,
+  options: ToMatchElementOptions = { ignoreProps: true }
 ): Matcher {
   let expectedWrapper: EnzymeObject;
   if (!isShallowWrapper(actualEnzymeWrapper)) {
@@ -22,8 +23,8 @@ function toMatchElement(
     expectedWrapper = shallow(reactInstance);
   }
 
-  const actual = actualEnzymeWrapper.debug();
-  const expected = expectedWrapper.debug();
+  const actual = actualEnzymeWrapper.debug(options);
+  const expected = expectedWrapper.debug(options);
   const pass = actual === expected;
 
   return {

--- a/packages/enzyme-matchers/src/types/ToMatchElementOptions.js
+++ b/packages/enzyme-matchers/src/types/ToMatchElementOptions.js
@@ -1,0 +1,11 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule ToMatchElementOptions
+ * @flow
+ */
+
+export type ToMatchElementOptions = {
+  ignoreProps?: boolean,
+};

--- a/packages/enzyme-matchers/src/types/index.js
+++ b/packages/enzyme-matchers/src/types/index.js
@@ -3,3 +3,4 @@
 export type { EnzymeObject } from './EnzymeObject';
 export type { Matcher } from './Matcher';
 export type { MatcherMethods } from './MatcherMethods';
+export type { ToMatchElementOptions } from './ToMatchElementOptions';


### PR DESCRIPTION
Fixes #163 `toMatchElement() does not behave like matchesElement()`.